### PR TITLE
Add quick add time increment buttons and display time difference

### DIFF
--- a/resources/js/Components/Modal.vue
+++ b/resources/js/Components/Modal.vue
@@ -103,17 +103,13 @@ export default {
             justify-content: flex-end;
             align-items: center;
             padding: 10px 20px;
-            border-top: 1px solid #eee;
+            border-top: 1px solid #eeeeee;
             position: absolute;
             bottom: 0;
             width: 100%;
             .modal-close {
                 margin-left: 10px;
                 position: relative;
-                background-color: #eeeeeecc;
-                &:hover {
-                    background-color: #eeeeee;
-                }
             }
             .modal-continue {
                 margin-left: 10px;

--- a/resources/js/Modals/ManualTimeSet.vue
+++ b/resources/js/Modals/ManualTimeSet.vue
@@ -3,6 +3,17 @@
     <div>
         <div class="mb-4">Enter a manual time to use when clocking in/out. This will be override the actual time.</div>
         <input id="manual-time-input" type="time">
+        <!-- Quick Add Buttons -->
+        <div class="mt-4">
+            <div class="item-group">
+                <button type="button" class="btn btn-2" @click="addTime(-15)">-15 Min</button>
+                <button type="button" class="btn btn-2" @click="addTime(15)">+15 Min</button>
+            </div>
+            <div class="item-group">
+                <button type="button" class="btn btn-2" @click="addTime(-60)">-1 Hr</button>
+                <button type="button" class="btn btn-2" @click="addTime(60)">+1 Hr</button>
+            </div>
+        </div>
     </div>
 </template>
 
@@ -10,9 +21,29 @@
 <script>
 export default {
     name: 'ManualTimeSet',
+    methods: {
+        addTime(timeToAdd) {
+            const timeInput = document.getElementById('manual-time-input');
+            const now = new Date();
+            now.setMinutes(now.getMinutes() + timeToAdd);
+            const hours = now.getHours().toString().padStart(2, '0');
+            const minutes = now.getMinutes().toString().padStart(2, '0');
+            timeInput.value = `${hours}:${minutes}`;
+        }
+    }
 }
 </script>
 
 <!-- Styling -->
 <style lang="scss" scoped>
+    .item-group {
+        display: inline-block;
+    }
+    .btn-2 {
+        margin-right: 10px;
+        margin-bottom: 10px;
+        :last-child {
+            margin-right: 0;
+        }
+    }
 </style>

--- a/resources/js/Modals/ManualTimeSet.vue
+++ b/resources/js/Modals/ManualTimeSet.vue
@@ -25,11 +25,29 @@ export default {
     methods: {
         addTime(timeToAdd) {
             const timeInput = document.getElementById('manual-time-input');
-            const now = new Date();
-            now.setMinutes(now.getMinutes() + timeToAdd);
-            const hours = now.getHours().toString().padStart(2, '0');
-            const minutes = now.getMinutes().toString().padStart(2, '0');
-            timeInput.value = `${hours}:${minutes}`;
+            // If there's no current value, start with current time
+            if (!timeInput.value) {
+                const now = new Date();
+                const hours = now.getHours().toString().padStart(2, '0');
+                const minutes = now.getMinutes().toString().padStart(2, '0');
+                timeInput.value = `${hours}:${minutes}`;
+            }
+            // Parse the current input value
+            const [hours, minutes] = timeInput.value.split(':').map(Number);
+            // Convert to total minutes, add the new time, then convert back
+            let totalMinutes = hours * 60 + minutes + timeToAdd;
+            // Handle negative times by wrapping around 24 hours
+            while (totalMinutes < 0) {
+                totalMinutes += 24 * 60;
+            }
+            // Handle times over 24 hours by wrapping
+            totalMinutes = totalMinutes % (24 * 60);
+            // Calculate new hours and minutes
+            const newHours = Math.floor(totalMinutes / 60).toString().padStart(2, '0');
+            const newMinutes = (totalMinutes % 60).toString().padStart(2, '0');
+            // Update the input value
+            timeInput.value = `${newHours}:${newMinutes}`;
+            // Update the time difference display
             this.updateTimeDifference();
         },
         updateTimeDifference() {

--- a/resources/js/Modals/ManualTimeSet.vue
+++ b/resources/js/Modals/ManualTimeSet.vue
@@ -11,8 +11,12 @@
                 <button type="button" class="btn btn-2" @click="addTime(5)">+5 Minutes</button>
             </div>
             <div class="item-group">
-                <button type="button" class="btn btn-2" @click="addTime(-60)">-1 Hr</button>
-                <button type="button" class="btn btn-2" @click="addTime(60)">+1 Hr</button>
+                <button type="button" class="btn btn-2" @click="addTime(-15)">-15 Minutes</button>
+                <button type="button" class="btn btn-2" @click="addTime(15)">+15 Minutes</button>
+            </div>
+            <div class="item-group">
+                <button type="button" class="btn btn-2" @click="addTime(-60)">-1 Hour</button>
+                <button type="button" class="btn btn-2" @click="addTime(60)">+1 Hour</button>
             </div>
         </div>
     </div>
@@ -110,10 +114,14 @@ export default {
     #quick-add-buttons {
         .item-group {
             display: inline-block;
+            width: 100%;
+            display: flex;
         }
         .btn-2 {
+            font-size: 14px;
             margin-right: 10px;
             margin-bottom: 10px;
+            flex-basis: 50%;
             :last-child {
                 margin-right: 0;
             }

--- a/resources/js/Modals/ManualTimeSet.vue
+++ b/resources/js/Modals/ManualTimeSet.vue
@@ -5,7 +5,7 @@
         <input class="mb-4" id="manual-time-input" type="time" @input="updateTimeDifference">
         <div class="mb-4" id="time-difference"></div>
         <!-- Quick Add Buttons -->
-        <div>
+        <div id="quick-add-buttons">
             <div class="item-group">
                 <button type="button" class="btn btn-2" @click="addTime(-15)">-15 Min</button>
                 <button type="button" class="btn btn-2" @click="addTime(15)">+15 Min</button>
@@ -80,26 +80,43 @@ export default {
             if (minutes > 0 || hours === 0) {
                 diffText += minutes + ' Min';
             }
-            timeDifferenceElement.textContent = diffText;
+            // Create HTML with text and icon
+            timeDifferenceElement.innerHTML = `${diffText} <i class="fas fa-window-close"></i>`;
+            // Add click event to the icon
+            const closeIcon = timeDifferenceElement.querySelector('.fa-window-close');
+            if (closeIcon) {
+                closeIcon.addEventListener('click', () => {
+                    timeInput.value = '';
+                    this.updateTimeDifference();
+                });
+            }
         }
     },
 }
 </script>
 
-<!-- Styling -->
-<style lang="scss" scoped>
+<!-- Styling (not scoped) -->
+<style lang="scss">
+    @import "../../sass/app.scss";
     #time-difference {
         display: inline-block;
         margin-left: 25px;
+        i.fa-window-close {
+            color: $color2;
+            margin-left: 15px;
+            cursor: pointer;
+        }
     }
-    .item-group {
-        display: inline-block;
-    }
-    .btn-2 {
-        margin-right: 10px;
-        margin-bottom: 10px;
-        :last-child {
-            margin-right: 0;
+    #quick-add-buttons {
+        .item-group {
+            display: inline-block;
+        }
+        .btn-2 {
+            margin-right: 10px;
+            margin-bottom: 10px;
+            :last-child {
+                margin-right: 0;
+            }
         }
     }
 </style>

--- a/resources/js/Modals/ManualTimeSet.vue
+++ b/resources/js/Modals/ManualTimeSet.vue
@@ -2,9 +2,10 @@
 <template>
     <div>
         <div class="mb-4">Enter a manual time to use when clocking in/out. This will be override the actual time.</div>
-        <input id="manual-time-input" type="time">
+        <input class="mb-4" id="manual-time-input" type="time">
+        <div class="mb-4" id="time-difference"></div>
         <!-- Quick Add Buttons -->
-        <div class="mt-4">
+        <div>
             <div class="item-group">
                 <button type="button" class="btn btn-2" @click="addTime(-15)">-15 Min</button>
                 <button type="button" class="btn btn-2" @click="addTime(15)">+15 Min</button>
@@ -36,6 +37,10 @@ export default {
 
 <!-- Styling -->
 <style lang="scss" scoped>
+    #time-difference {
+        display: inline-block;
+        margin-left: 25px;
+    }
     .item-group {
         display: inline-block;
     }

--- a/resources/js/Modals/ManualTimeSet.vue
+++ b/resources/js/Modals/ManualTimeSet.vue
@@ -116,14 +116,14 @@ export default {
             display: inline-block;
             width: 100%;
             display: flex;
-        }
-        .btn-2 {
-            font-size: 14px;
-            margin-right: 10px;
-            margin-bottom: 10px;
-            flex-basis: 50%;
-            :last-child {
-                margin-right: 0;
+            .btn-2 {
+                font-size: 14px;
+                margin-right: 10px;
+                margin-bottom: 10px;
+                flex-basis: 50%;
+                :last-child {
+                    margin-right: 0;
+                }
             }
         }
     }

--- a/resources/js/Modals/ManualTimeSet.vue
+++ b/resources/js/Modals/ManualTimeSet.vue
@@ -7,8 +7,8 @@
         <!-- Quick Add Buttons -->
         <div id="quick-add-buttons">
             <div class="item-group">
-                <button type="button" class="btn btn-2" @click="addTime(-15)">-15 Min</button>
-                <button type="button" class="btn btn-2" @click="addTime(15)">+15 Min</button>
+                <button type="button" class="btn btn-2" @click="addTime(-5)">-5 Minutes</button>
+                <button type="button" class="btn btn-2" @click="addTime(5)">+5 Minutes</button>
             </div>
             <div class="item-group">
                 <button type="button" class="btn btn-2" @click="addTime(-60)">-1 Hr</button>

--- a/resources/js/Modals/ManualTimeSet.vue
+++ b/resources/js/Modals/ManualTimeSet.vue
@@ -2,7 +2,7 @@
 <template>
     <div>
         <div class="mb-4">Enter a manual time to use when clocking in/out. This will be override the actual time.</div>
-        <input class="mb-4" id="manual-time-input" type="time">
+        <input class="mb-4" id="manual-time-input" type="time" @input="updateTimeDifference">
         <div class="mb-4" id="time-difference"></div>
         <!-- Quick Add Buttons -->
         <div>
@@ -30,8 +30,41 @@ export default {
             const hours = now.getHours().toString().padStart(2, '0');
             const minutes = now.getMinutes().toString().padStart(2, '0');
             timeInput.value = `${hours}:${minutes}`;
+            this.updateTimeDifference();
+        },
+        updateTimeDifference() {
+            const timeInput = document.getElementById('manual-time-input');
+            const timeDifferenceElement = document.getElementById('time-difference');
+            // Clear when no time is set
+            if (!timeInput.value) {
+                timeDifferenceElement.textContent = '';
+                return;
+            }
+            // Get current time
+            const now = new Date();
+            const currentHours = now.getHours();
+            const currentMinutes = now.getMinutes();
+            // Get manual time
+            const [manualHours, manualMinutes] = timeInput.value.split(':').map(Number);
+            // Calculate difference in minutes
+            const currentTotalMinutes = currentHours * 60 + currentMinutes;
+            const manualTotalMinutes = manualHours * 60 + manualMinutes;
+            let diffMinutes = manualTotalMinutes - currentTotalMinutes;
+            // Format the output
+            const sign = diffMinutes >= 0 ? '+ ' : '- ';
+            diffMinutes = Math.abs(diffMinutes);
+            const hours = Math.floor(diffMinutes / 60);
+            const minutes = diffMinutes % 60;
+            let diffText = sign;
+            if (hours > 0) {
+                diffText += hours === 1 ? '1 Hr ' : hours + ' Hrs ';
+            }
+            if (minutes > 0 || hours === 0) {
+                diffText += minutes + ' Min';
+            }
+            timeDifferenceElement.textContent = diffText;
         }
-    }
+    },
 }
 </script>
 

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -14,6 +14,7 @@ $font_body: $nunito;
 $color1: #5f56ff;
 $color1-light: #dedcff;
 $color2: #009FBD; // Modals, etc
+$color2-light: #ddf1f5;
 $color3: #F9E2AF; // Not used at this time
 $black: #1B2F33;
 $white: white;
@@ -75,6 +76,13 @@ a {
     &:hover {
         background-color: $color1;
         color: $white;
+    }
+}
+.btn-2, .modal-close {
+    background-color: #eeeeeecc;
+    color: $color2;
+    &:hover {
+        background-color: $color2-light;
     }
 }
 

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -94,16 +94,15 @@ select, input, textarea {
 }
 // Forms: Autocomplete
 .autocomplete {
-    /*the container must be positioned relative:*/
     position: relative;
 }
 .autocomplete-items {
-    position: absolute;
     border: 1px solid #d4d4d4;
     border-bottom: none;
     border-top: none;
     z-index: 99;
-    /*position the autocomplete items to be the same width as the container:*/
+    // Position the autocomplete items to be the same width as the container
+    position: absolute;
     top: 100%;
     left: 0;
     right: 0;
@@ -115,11 +114,10 @@ select, input, textarea {
     border-bottom: 1px solid #d4d4d4;
 }
 .autocomplete-items div:hover {
-    /*when hovering an item:*/
     background-color: #e9e9e9;
 }
 .autocomplete-active {
-    /*when navigating through the items using the arrow keys:*/
+    // When navigating through the items using the arrow keys
     background-color: DodgerBlue !important;
     color: #ffffff;
 }


### PR DESCRIPTION
This update adds quick-add buttons to the manual time modal. Users can easily add or subtract time in increments of 5 minutes, 15 minutes, and 1 hour. There is also a time difference display that is next to the time input field.

![image](https://github.com/user-attachments/assets/676188b5-094a-4b51-a717-432e4abb4d70)